### PR TITLE
Only run command if directory actually exists.

### DIFF
--- a/lib/capistrano/templates/run.erb
+++ b/lib/capistrano/templates/run.erb
@@ -1,3 +1,7 @@
 #!/bin/sh
-cd <%= current_path %>
-<%= _runit_command %>
+if [ -d <%= current_path %> ]; then
+  cd <%= current_path %>
+  <%= _runit_command %>
+else
+  echo "Directory <%= current_path %> is missing. Retrying ..."
+fi


### PR DESCRIPTION
If the current_path shouldn't exist, which could happen during the very first deployment, it tries to run the command anyway, which could generate a lot of error messages in runit's log. So instead just wait until the necessary directory is available and only try then to run the actual command.
